### PR TITLE
Dev transpose

### DIFF
--- a/mdtensor/core/type.hpp
+++ b/mdtensor/core/type.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <concepts>
+
 #ifndef MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_ // NOTE: for godbolt test
 #include <experimental/mdarray>
 #include <experimental/mdspan> // TODO: Remove when C++23 std::mdspan supports

--- a/mdtensor/creation/arange.hpp
+++ b/mdtensor/creation/arange.hpp
@@ -75,4 +75,7 @@ template <typename data_t = void, arithmetic_c stop_t>
     return arange<data_t>(0, std::forward<stop_t>(stop));
 }
 
+// TODO: Develop arange that works in compile-time contexts (e.g., constexpr
+// mdarray) and/or with static extents.
+
 } // namespace mdtensor

--- a/mdtensor/manipulation/manipulation.hpp
+++ b/mdtensor/manipulation/manipulation.hpp
@@ -12,3 +12,4 @@
 #include "concatenate.hpp"
 #include "expand_dims.hpp"
 #include "reshape.hpp"
+#include "transpose.hpp"

--- a/mdtensor/manipulation/transpose.hpp
+++ b/mdtensor/manipulation/transpose.hpp
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * @brief Transpose utilities for mdtensor.
+ *
+ * @copyright
+ * SPDX-License-Identifier: Apache-2.0
+ * See README and LICENSE files for full attribution details.
+ */
+
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include <utility>
+
+#include "../core/core.hpp"
+
+namespace mdtensor {
+
+template <typename in_t, std::integral AxesType, AxesType... Axes>
+[[nodiscard]] inline constexpr auto
+transpose(in_t &&in, std::integer_sequence<AxesType, Axes...>) noexcept {
+    const auto in_mds = core::to_mdspan(std::forward<in_t>(in));
+    using in_mds_t = decltype(in_mds);
+
+    constexpr size_t rank = in_mds_t::rank();
+
+    static_assert(sizeof...(Axes) == rank, "Number of axes must match rank.");
+
+    if constexpr (rank == 0 || rank == 1) {
+        return in_mds;
+
+    } else {
+        constexpr auto axes = std::array<size_t, rank>{static_cast<size_t>(
+            ((Axes % static_cast<AxesType>(rank)) + (rank)) % rank)...};
+
+        const auto new_extents = [&]<size_t... Is>(std::index_sequence<Is...>) {
+            return extents<typename in_mds_t::index_type,
+                           in_mds_t::static_extent(axes[Is])...>{
+                in_mds.extent(axes[Is])...};
+        }(std::make_index_sequence<rank>{});
+
+        const auto new_strides = [&]<size_t... Is>(std::index_sequence<Is...>) {
+            return std::array<typename in_mds_t::index_type, rank>{
+                in_mds.stride(axes[Is])...};
+        }(std::make_index_sequence<rank>{});
+
+        return mdspan<typename in_mds_t::element_type,
+                      std::remove_cvref_t<decltype(new_extents)>, layout_stride,
+                      typename in_mds_t::accessor_type>{
+            in_mds.data_handle(),
+            layout_stride::mapping{new_extents, new_strides}};
+    }
+}
+
+template <typename in_t>
+[[nodiscard]] inline constexpr auto transpose(in_t &&in) noexcept {
+    const auto in_mds = core::to_mdspan(std::forward<in_t>(in));
+    using in_mds_t = decltype(in_mds);
+
+    constexpr size_t rank = in_mds_t::rank();
+
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return transpose(std::forward<in_t>(in),
+                         std::integer_sequence<int64_t, rank - 1 - Is...>{});
+    }(std::make_index_sequence<rank>{});
+}
+
+} // namespace mdtensor

--- a/tests/manipulation/transpose/BUILD.bazel
+++ b/tests/manipulation/transpose/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:mdtensor",
+    ],
+)

--- a/tests/manipulation/transpose/main.cpp
+++ b/tests/manipulation/transpose/main.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include "mdtensor/creation/arange.hpp"
+#include "mdtensor/creation/ones.hpp"
+#include "mdtensor/logic/array_equal.hpp"
+#include "mdtensor/manipulation/reshape.hpp"
+#include "mdtensor/manipulation/transpose.hpp"
+
+namespace md = mdtensor;
+
+TEST(test, 1) {
+    using T = double;
+
+    constexpr auto a = md::mdarray<T, md::extents<size_t, 2, 2>>{
+        {1, 2, 3, 4}, md::extents<size_t, 2, 2>{}};
+
+    static_assert(md::array_equal(
+        md::transpose(a), md::mdarray<T, md::extents<size_t, 2, 2>>{
+                              {1, 3, 2, 4}, md::extents<size_t, 2, 2>{}}));
+}
+
+TEST(test, 2) {
+    using T = double;
+
+    constexpr auto a = md::mdarray<T, md::extents<size_t, 4>>{
+        {1, 2, 3, 4}, md::extents<size_t, 4>{}};
+
+    static_assert(md::array_equal(md::transpose(a), a));
+}
+
+TEST(test, 3) {
+    using T = double;
+
+    constexpr auto a = md::ones<T>(md::extents<size_t, 1, 2, 3>{});
+
+    static_assert(md::core::same(
+        md::transpose(a, std::integer_sequence<size_t, 1, 0, 2>{}).extents(),
+        md::extents<size_t, 2, 1, 3>{}));
+}
+
+TEST(test, 4) {
+    using T = double;
+
+    constexpr auto a = md::ones<T>(md::extents<size_t, 2, 3, 4, 5>{});
+
+    static_assert(md::core::same(md::transpose(a).extents(),
+                                 md::extents<size_t, 5, 4, 3, 2>{}));
+}
+
+TEST(test, 5) {
+    using T = double;
+
+    const auto a = md::arange<T>(60);
+
+    ASSERT_TRUE(md::core::same(
+        md::transpose(md::reshape(a, md::extents<size_t, 3, 4, 5>{}),
+                      std::integer_sequence<int, -1, 0, -2>{})
+            .extents(),
+        md::extents<size_t, 5, 3, 4>{}));
+}


### PR DESCRIPTION
This pull request introduces a new `transpose` utility for the `mdtensor` library, enabling flexible and efficient transposition of multidimensional arrays, including support for negative and out-of-order axes. The update adds both the implementation and comprehensive tests, and integrates the new operation into the manipulation module.

**Transpose operation implementation:**

* Added `transpose.hpp` in `mdtensor/manipulation/` implementing a constexpr-friendly `transpose` function that supports arbitrary axis permutations, negative axis indices, and is compatible with compile-time contexts.
* Included the new `transpose.hpp` in the `manipulation.hpp` header to make the transpose operation available as part of the manipulation module.

**Testing and build integration:**

* Added a Bazel test target for transpose functionality in `tests/manipulation/transpose/BUILD.bazel`.
* Implemented a comprehensive test suite in `tests/manipulation/transpose/main.cpp`, covering 1D, 2D, and higher-dimensional arrays, as well as edge cases like negative and reordered axes.

**General improvements:**

* Added a `#include <concepts>` in `mdtensor/core/type.hpp` to support the use of concepts in the new implementation.
* Added a TODO comment in `arange.hpp` noting the intent to develop a compile-time-friendly `arange` for use with static extents.