### PR TITLE
Dev broadcast to

### DIFF
--- a/mdtensor/core/broadcast.hpp
+++ b/mdtensor/core/broadcast.hpp
@@ -77,65 +77,109 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
 
 namespace detail {
 
-template <size_t Is, size_t brank, extents_c in1_t, extents_c in2_t>
-constexpr size_t broadcast_static_extent(in1_t &&in = in1_t{},
-                                         in2_t &&in2 = in2_t{}) noexcept {
-    constexpr size_t e1 =
-        (Is < brank - in1_t::rank()
-             ? 1
-             : in1_t::static_extent(Is - (brank - in1_t::rank())));
-    constexpr size_t e2 =
-        (Is < brank - in2_t::rank()
-             ? 1
-             : in2_t::static_extent(Is - (brank - in2_t::rank())));
-    static_assert(e1 == e2 || e1 == 1 || e1 == dyn || e2 == 1 || e2 == dyn,
-                  "incompatible extents for broadcasting.");
+template <size_t I, size_t brank, extents_c in_t>
+[[nodiscard]] inline constexpr size_t aligned_static_extent() noexcept {
+    using in_base_t = std::remove_cvref_t<in_t>;
 
-    return std::max(e1, e2);
+    constexpr size_t rank = in_base_t::rank();
+
+    if constexpr (I < brank - rank) {
+        return 1;
+
+    } else {
+        return in_base_t::static_extent(I - (brank - rank));
+    }
+}
+
+template <size_t... Exts>
+[[nodiscard]] inline constexpr size_t broadcast_static_extent() noexcept {
+
+    static_assert(
+        [&] {
+            constexpr auto exts = std::array{Exts...};
+
+            for (size_t i = 0; i < sizeof...(Exts); i++) {
+                for (size_t j = i + 1; j < sizeof...(Exts); j++) {
+                    const size_t ei = exts[i];
+                    const size_t ej = exts[j];
+
+                    if (ei != ej && ei != 1 && ei != dyn && ej != 1 &&
+                        ej != dyn) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }(),
+        "Incompatible static extents for broadcasting.");
+
+    return std::max({Exts...});
+}
+
+template <size_t I, size_t brank, extents_c in_t>
+[[nodiscard]] inline constexpr auto aligned_extent(in_t &&in) noexcept {
+    using in_base_t = std::remove_cvref_t<in_t>;
+
+    constexpr size_t rank = in_base_t::rank();
+
+    if constexpr (I < brank - rank) {
+        return typename in_base_t::index_type{1};
+
+    } else {
+        return in.extent(I - (brank - rank));
+    }
+}
+
+template <typename index_t, typename... exts_t>
+[[nodiscard]] inline constexpr index_t
+broadcast_extent(exts_t... exts) noexcept {
+    assert([&] {
+        for (size_t i = 0; i < sizeof...(exts); i++) {
+            for (size_t j = i + 1; j < sizeof...(exts); j++) {
+                const index_t ei = std::get<i>(std::forward_as_tuple(exts...));
+                const index_t ej = std::get<j>(std::forward_as_tuple(exts...));
+
+                if (ei != ej && ei != 1 && ej != 1) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }());
+
+    return std::max({static_cast<index_t>(exts)...});
 }
 
 } // namespace detail
 
-template <extents_c in_t>
-[[nodiscard]] inline constexpr auto broadcast(in_t &&in = in_t{}) noexcept {
-    return std::forward<in_t>(in);
-}
+template <extents_c... ins_t>
+[[nodiscard]] inline constexpr auto broadcast(ins_t &&...ins) noexcept {
+    using index_t =
+        common_index_type_t<typename std::remove_cvref_t<ins_t>::index_type...>;
 
-template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
-[[nodiscard]] inline constexpr auto broadcast(in1_t &&in1 = in1_t{},
-                                              in2_t &&in2 = in2_t{},
-                                              ins_t &&...ins) noexcept {
-    using in1_base_t = std::remove_cvref_t<in1_t>;
-    using in2_base_t = std::remove_cvref_t<in2_t>;
-    using index_t = common_index_type_t<typename in1_base_t::index_type,
-                                        typename in2_base_t::index_type>;
+    constexpr size_t brank = std::max({std::remove_cvref_t<ins_t>::rank()...});
 
-    constexpr size_t brank = std::max(in1_base_t::rank(), in2_base_t::rank());
-
-    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return extents<index_t, detail::broadcast_static_extent<
-                                    Is, brank, in1_base_t, in2_base_t>()...>{
-            [&]() {
-                const size_t x1 =
-                    (Is < brank - in1_base_t::rank()
-                         ? 1
-                         : in1.extent(Is - (brank - in1_base_t::rank())));
-                const size_t x2 =
-                    (Is < brank - in2_base_t::rank()
-                         ? 1
-                         : in2.extent(Is - (brank - in2_base_t::rank())));
-
-                assert(x1 == x2 || x1 == 1 || x2 == 1);
-
-                return std::max(x1, x2);
-            }()...};
-    }(std::make_index_sequence<brank>{});
-
-    if constexpr (sizeof...(ins_t) == 0) {
-        return bexts;
+    if constexpr (brank == 0) {
+        return extents<index_t>{};
 
     } else {
-        return broadcast(bexts, std::forward<ins_t>(ins)...);
+        return [&]<size_t... Is>(std::index_sequence<Is...>) {
+            const auto static_extent_at = [&]<size_t I>() {
+                return detail::broadcast_static_extent<
+                    detail::aligned_static_extent<I, brank, ins_t>()...>();
+            };
+
+            const auto extent_at = [&]<size_t I>() {
+                return detail::broadcast_extent<index_t>(
+                    detail::aligned_extent<I, brank>(
+                        std::forward<ins_t>(ins))...);
+            };
+
+            return extents<index_t,
+                           static_extent_at.template operator()<Is>()...> {
+                extent_at.template operator()<Is>()...
+            };
+        }(std::make_index_sequence<brank>{});
     }
 }
 

--- a/mdtensor/core/broadcast.hpp
+++ b/mdtensor/core/broadcast.hpp
@@ -49,9 +49,9 @@ slice_from_right(in_t &&in = in_t{}) noexcept {
 }
 
 template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
-[[nodiscard]] inline constexpr auto concatenate(in1_t &&in1 = in1_t{},
-                                                in2_t &&in2 = in2_t{},
-                                                ins_t &&...ins) noexcept {
+[[nodiscard]] inline constexpr auto
+concatenate_extents(in1_t &&in1 = in1_t{}, in2_t &&in2 = in2_t{},
+                    ins_t &&...ins) noexcept {
     using in1_base_t = std::remove_cvref_t<in1_t>;
     using in2_base_t = std::remove_cvref_t<in2_t>;
     using index_t = common_index_type_t<typename in1_base_t::index_type,
@@ -71,7 +71,7 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
         return cexts;
 
     } else {
-        return concatenate(cexts, std::forward<ins_t>(ins)...);
+        return concatenate_extents(cexts, std::forward<ins_t>(ins)...);
     }
 }
 
@@ -153,7 +153,7 @@ broadcast_extent(exts_t... exts) noexcept {
 } // namespace detail
 
 template <extents_c... ins_t>
-[[nodiscard]] inline constexpr auto broadcast(ins_t &&...ins) noexcept {
+[[nodiscard]] inline constexpr auto broadcast_extents(ins_t &&...ins) noexcept {
     using index_t =
         common_index_type_t<typename std::remove_cvref_t<ins_t>::index_type...>;
 
@@ -185,8 +185,8 @@ template <extents_c... ins_t>
 
 template <size_t offset, size_t brank, mdspan_c in_t, extents_c new_bexts_t>
 [[nodiscard]] inline constexpr auto
-broadcast_to(in_t &&in = in_t{},
-             new_bexts_t &&new_bexts = new_bexts_t{}) noexcept {
+broadcast_axes_to(in_t &&in = in_t{},
+                  new_bexts_t &&new_bexts = new_bexts_t{}) noexcept {
     using in_base_t = std::remove_cvref_t<in_t>;
     using new_bexts_base_t = std::remove_cvref_t<new_bexts_t>;
 
@@ -258,11 +258,12 @@ broadcast_to(in_t &&in = in_t{},
 
         const auto new_extents = [&]() {
             if constexpr (offset == 0) {
-                return concatenate(std::forward<new_bexts_t>(new_bexts),
-                                   slice_from_right<urank>(in.extents()));
+                return concatenate_extents(
+                    std::forward<new_bexts_t>(new_bexts),
+                    slice_from_right<urank>(in.extents()));
 
             } else {
-                return concatenate(
+                return concatenate_extents(
                     slice_from_left<offset>(in.extents()),
                     std::forward<new_bexts_t>(new_bexts),
                     slice_from_right<urank - offset>(in.extents()));
@@ -391,16 +392,16 @@ create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
     auto ins_tuple = std::forward_as_tuple(ins...);
 
     const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return broadcast(slice_with_offset<ofst[Is], br[Is]>(
+        return broadcast_extents(slice_with_offset<ofst[Is], br[Is]>(
             std::get<Is>(ins_tuple).extents())...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
     constexpr size_t uout_offset = ofst[sizeof...(ins_t)];
 
-    return create_data<value_t>(
-        concatenate(slice_from_left<uout_offset>(uout_exts), bexts,
-                    slice_from_right<std::remove_cvref_t<uout_exts_t>::rank() -
-                                     uout_offset>(uout_exts)));
+    return create_data<value_t>(concatenate_extents(
+        slice_from_left<uout_offset>(uout_exts), bexts,
+        slice_from_right<std::remove_cvref_t<uout_exts_t>::rank() -
+                         uout_offset>(uout_exts)));
 }
 
 template <typename dtype = void, size_t... uranks, extents_c uout_exts_t,
@@ -456,12 +457,12 @@ create_outs(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
     auto ins_tuple = std::forward_as_tuple(ins...);
 
     const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return broadcast(slice_with_offset<ofst[Is], br[Is]>(
+        return broadcast_extents(slice_with_offset<ofst[Is], br[Is]>(
             std::get<Is>(ins_tuple).extents())...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
     return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return std::tuple{create_data<value_t>(concatenate(
+        return std::tuple{create_data<value_t>(concatenate_extents(
             slice_from_left<ofst[sizeof...(ins_t) + Is]>(
                 std::get<Is>(uout_exts_tuple)),
             bexts,
@@ -567,7 +568,7 @@ inline constexpr void batch(func_t &&func, std::index_sequence<offsets...>,
                     std::index_sequence<offsets...>{},
                     static_reshape(
                         std::get<Is>(ins_tuple),
-                        concatenate(
+                        concatenate_extents(
                             slice_from_left<ofst[Is]>(
                                 std::get<Is>(ins_tuple).extents()),
                             extents<size_t, static_bsize>{static_bsize},
@@ -584,15 +585,15 @@ inline constexpr void batch(func_t &&func, std::index_sequence<offsets...>,
 
     } else {
         const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-            return broadcast(slice_with_offset<ofst[Is], br[Is]>(
+            return broadcast_extents(slice_with_offset<ofst[Is], br[Is]>(
                 std::get<Is>(ins_tuple).extents())...);
         }(std::make_index_sequence<sizeof...(ins_t)>{});
 
         [&]<size_t... Is>(std::index_sequence<Is...>) {
             detail::batch_impl<mpmode, decltype(bexts)::rank()>(
                 std::forward<func_t>(func), std::index_sequence<offsets...>{},
-                broadcast_to<ofst[Is], br[Is]>(std::get<Is>(ins_tuple),
-                                               bexts)...);
+                broadcast_axes_to<ofst[Is], br[Is]>(std::get<Is>(ins_tuple),
+                                                    bexts)...);
         }(std::make_index_sequence<sizeof...(ins_t)>{});
     }
 }

--- a/mdtensor/core/type.hpp
+++ b/mdtensor/core/type.hpp
@@ -321,7 +321,8 @@ struct common_index_type_impl<U, S>
     : common_index_type_impl<std::remove_cvref_t<S>, std::remove_cvref_t<U>> {};
 
 template <typename T1, typename T2, typename... Ts>
-    requires requires { typename common_index_type_impl<T1, T2>::type; }
+    requires(sizeof...(Ts) > 0 &&
+             requires { typename common_index_type_impl<T1, T2>::type; })
 struct common_index_type_impl<T1, T2, Ts...> {
   public:
     using type = typename common_index_type_impl<

--- a/mdtensor/creation/linspace.hpp
+++ b/mdtensor/creation/linspace.hpp
@@ -170,7 +170,7 @@ linspace(start_t &&start, stop_t &&stop, const exts_t &exts = exts_t{},
         ((Axis % static_cast<int64_t>(out_rank)) + (out_rank)) % out_rank);
 
     const auto bexts = start_mds.extents();
-    auto out = core::create_data<value_t>(core::concatenate(
+    auto out = core::create_data<value_t>(core::concatenate_extents(
         core::slice_from_left<axis>(bexts), exts,
         core::slice_from_right<decltype(bexts)::rank() - axis>(bexts)));
 

--- a/mdtensor/manipulation/broadcast_to.hpp
+++ b/mdtensor/manipulation/broadcast_to.hpp
@@ -49,16 +49,39 @@ broadcast_to(in_t &&in,
     } else {
         using index_t = typename new_extents_base_t::index_type;
 
+        // ni = new_rank - org_rank + oi
+        const auto get_ni = [](size_t i) { return new_rank - org_rank + i; };
+
+        // assertion
+        static_assert(
+            [&] {
+                for (size_t i = 0; i < org_rank; i++) {
+                    if (in_mds_base_t::static_extent(i) !=
+                            new_extents_base_t::static_extent(get_ni(i)) &&
+                        in_mds_base_t::static_extent(i) != 1 &&
+                        new_extents_base_t::static_extent(get_ni(i)) != dyn) {
+                        return false;
+                    }
+                }
+                return true;
+            }(),
+            "Incompatible extents for broadcasting.");
+
+        for (size_t i = 0; i < org_rank; i++) {
+            assert(static_cast<size_t>(in_mds.extent(i)) ==
+                       static_cast<size_t>(new_extents.extent(get_ni(i))) ||
+                   static_cast<size_t>(in_mds.extent(i)) == 1);
+        }
+
+        // calculation
         auto new_strides = std::array<index_t, new_rank>{};
 
-        for (size_t i = 0; i < new_rank; i++) {
-            if (i < new_rank - org_rank) {
-                new_strides[i] = 0;
+        for (size_t i = 0; i < new_rank - org_rank; i++) {
+            new_strides[i] = 0;
+        }
 
-            } else {
-                new_strides[i] = static_cast<index_t>(
-                    in_mds.stride(i - (new_rank - org_rank)));
-            }
+        for (size_t i = 0; i < org_rank; i++) {
+            new_strides[get_ni(i)] = static_cast<index_t>(in_mds.stride(i));
         }
 
         return mdspan<typename in_mds_base_t::element_type, new_extents_base_t,

--- a/mdtensor/manipulation/broadcast_to.hpp
+++ b/mdtensor/manipulation/broadcast_to.hpp
@@ -1,0 +1,72 @@
+/**
+ * @file
+ * @brief Broadcast_to utilities for mdtensor.
+ *
+ * @copyright
+ * SPDX-License-Identifier: Apache-2.0
+ * See README and LICENSE files for full attribution details.
+ */
+
+#pragma once
+
+#include "../core/core.hpp"
+
+namespace mdtensor {
+
+template <typename in_t, extents_c new_extents_t>
+[[nodiscard]] inline constexpr auto
+broadcast_to(in_t &&in,
+             new_extents_t &&new_extents = new_extents_t{}) noexcept {
+    const auto in_mds = core::to_const_mdspan(std::forward<in_t>(in));
+
+    using in_mds_base_t = std::remove_cvref_t<decltype(in_mds)>;
+    using new_extents_base_t = std::remove_cvref_t<new_extents_t>;
+
+    constexpr size_t org_rank = in_mds_base_t::rank();
+    constexpr size_t new_rank = new_extents_base_t::rank();
+
+    static_assert(org_rank <= new_rank, "Incompatible ranks for broadcasting.");
+
+    if constexpr (core::same<typename in_mds_base_t::extents_type,
+                             new_extents_base_t>()) {
+        return std::forward<in_t>(in);
+
+    } else if constexpr (org_rank == 0) {
+        using index_t = typename new_extents_base_t::index_type;
+
+        auto new_strides = std::array<index_t, new_rank>{};
+
+        for (size_t i = 0; i < new_rank; i++) {
+            new_strides[i] = 0;
+        }
+
+        return mdspan<typename in_mds_base_t::element_type, new_extents_base_t,
+                      layout_stride, typename in_mds_base_t::accessor_type>{
+            in_mds.data_handle(),
+            layout_stride::mapping{std::forward<new_extents_t>(new_extents),
+                                   new_strides}};
+
+    } else {
+        using index_t = typename new_extents_base_t::index_type;
+
+        auto new_strides = std::array<index_t, new_rank>{};
+
+        for (size_t i = 0; i < new_rank; i++) {
+            if (i < new_rank - org_rank) {
+                new_strides[i] = 0;
+
+            } else {
+                new_strides[i] = static_cast<index_t>(
+                    in_mds.stride(i - (new_rank - org_rank)));
+            }
+        }
+
+        return mdspan<typename in_mds_base_t::element_type, new_extents_base_t,
+                      layout_stride, typename in_mds_base_t::accessor_type>{
+            in_mds.data_handle(),
+            layout_stride::mapping{std::forward<new_extents_t>(new_extents),
+                                   new_strides}};
+    }
+}
+
+} // namespace mdtensor

--- a/mdtensor/manipulation/manipulation.hpp
+++ b/mdtensor/manipulation/manipulation.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "broadcast_to.hpp"
 #include "concatenate.hpp"
 #include "expand_dims.hpp"
 #include "reshape.hpp"

--- a/tests/core/broadcast/main.cpp
+++ b/tests/core/broadcast/main.cpp
@@ -4,59 +4,59 @@
 
 namespace md = mdtensor;
 
-TEST(broadcast, 1) {
+TEST(broadcast_extents, 1) {
     auto exts1 = md::extents<size_t, 8, 6, 2, 3, 1, 4>{};
 
-    auto bexts = md::core::broadcast(exts1);
+    auto bexts = md::core::broadcast_extents(exts1);
 
     static_assert(md::core::same(bexts, exts1));
 }
 
-TEST(broadcast, 2) {
+TEST(broadcast_extents, 2) {
     auto exts1 = md::extents<size_t, 8, 6, 2, 3, 1, 4>{};
     auto exts2 = md::extents<size_t, 1, 3, 5, 4>{};
 
-    auto bexts = md::core::broadcast(exts1, exts2);
+    auto bexts = md::core::broadcast_extents(exts1, exts2);
 
     static_assert(
         md::core::same(bexts, md::extents<size_t, 8, 6, 2, 3, 5, 4>{}));
 }
 
-TEST(broadcast, 3) {
+TEST(broadcast_extents, 3) {
     auto exts1 = md::extents<size_t, 8, 6, 2, 3, 1, 4>{};
     auto exts2 = md::extents<size_t, 1, 3, 1, 4>{};
     auto exts3 = md::extents<size_t, 2, 1, 5, 1>{};
 
-    auto bexts = md::core::broadcast(exts1, exts2, exts3);
+    auto bexts = md::core::broadcast_extents(exts1, exts2, exts3);
 
     static_assert(
         md::core::same(bexts, md::extents<size_t, 8, 6, 2, 3, 5, 4>{}));
 }
 
-TEST(broadcast_to, 1) {
+TEST(broadcast_axes_to, 1) {
     auto mda = md::mdarray<int, md::extents<size_t, 1, 3, 2>>{};
     auto bexts = md::extents<size_t, 4, 5, 3>{};
 
-    auto bcast_mda = md::core::broadcast_to<0, 3>(mda.to_mdspan(), bexts);
+    auto bcast_mda = md::core::broadcast_axes_to<0, 3>(mda.to_mdspan(), bexts);
 
     static_assert(md::core::same(bcast_mda.extents(), bexts));
 }
 
-TEST(broadcast_to, 2) {
+TEST(broadcast_axes_to, 2) {
     auto mda = md::mdarray<int, md::extents<size_t, 4, 1, 3, 2>>{};
     auto bexts = md::extents<size_t, 4, 5, 3>{};
 
-    auto bcast_mda = md::core::broadcast_to<0, 3>(mda.to_mdspan(), bexts);
+    auto bcast_mda = md::core::broadcast_axes_to<0, 3>(mda.to_mdspan(), bexts);
 
     static_assert(
         md::core::same(bcast_mda.extents(), md::extents<size_t, 4, 5, 3, 2>{}));
 }
 
-TEST(broadcast_to, 3) {
+TEST(broadcast_axes_to, 3) {
     auto mda = md::mdarray<int, md::extents<size_t, 7, 4, 1, 3, 2>>{};
     auto bexts = md::extents<size_t, 4, 5, 3>{};
 
-    auto bcast_mda = md::core::broadcast_to<1, 3>(mda.to_mdspan(), bexts);
+    auto bcast_mda = md::core::broadcast_axes_to<1, 3>(mda.to_mdspan(), bexts);
 
     static_assert(md::core::same(bcast_mda.extents(),
                                  md::extents<size_t, 7, 4, 5, 3, 2>{}));

--- a/tests/core/common_type/data/main.cpp
+++ b/tests/core/common_type/data/main.cpp
@@ -151,3 +151,7 @@ TEST(test, bool_with_fpoint) {
     static_assert(std::same_as<test_t<bool, float>, float>);
     static_assert(std::same_as<test_t<bool, double>, double>);
 }
+
+TEST(test, triple) {
+    static_assert(std::same_as<test_t<float, float, float>, float>);
+}

--- a/tests/core/common_type/index/main.cpp
+++ b/tests/core/common_type/index/main.cpp
@@ -97,3 +97,7 @@ TEST(test, int_with_uint) {
     static_assert(std::same_as<test_t<int64_t, uint32_t>, int64_t>);
     static_assert(!assigned<int64_t, uint64_t>);
 }
+
+TEST(test, triple) {
+    static_assert(std::same_as<test_t<int16_t, int16_t, int16_t>, int16_t>);
+}

--- a/tests/manipulation/broadcast_to/BUILD.bazel
+++ b/tests/manipulation/broadcast_to/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:mdtensor",
+    ],
+)

--- a/tests/manipulation/broadcast_to/main.cpp
+++ b/tests/manipulation/broadcast_to/main.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+
+#include "mdtensor/logic/array_equal.hpp"
+#include "mdtensor/manipulation/broadcast_to.hpp"
+
+namespace md = mdtensor;
+
+TEST(test, 1) {
+    using T = double;
+
+    constexpr auto a = md::mdarray<T, md::extents<size_t, 3>>{{1, 2, 3}};
+
+    static_assert(
+        md::array_equal(md::broadcast_to(a, md::extents<size_t, 3, 3>{}),
+                        md::mdarray<T, md::extents<size_t, 3, 3>>{
+                            {1, 2, 3, 1, 2, 3, 1, 2, 3}}));
+}


### PR DESCRIPTION
This pull request refactors and extends the broadcasting functionality in the `mdtensor` library. The main changes include renaming and splitting core broadcasting functions for clarity, improving broadcasting implementation, and adding a new public `broadcast_to` utility. It also updates tests and adds new ones to cover the changes.

### Broadcasting API refactor and improvements

* Renamed the core broadcasting function from `broadcast` to `broadcast_extents` for clarity, and updated all internal usages accordingly. The function now handles multiple extents more robustly and includes improved static and runtime checks for broadcasting compatibility. (`mdtensor/core/broadcast.hpp`, `tests/core/broadcast/main.cpp`) [[1]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL52-R53) [[2]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL74-R188) [[3]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL217-R266) [[4]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL350-R402) [[5]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL415-R465) [[6]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL526-R571) [[7]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL543-R595) [[8]](diffhunk://#diff-39f7991edb781fe08db367150344847d94d7439221afe2f72cea133596e790afL7-R59)
* Renamed the axis-based broadcasting function from `broadcast_to` to `broadcast_axes_to` to distinguish it from the new public API, and updated all relevant usages. (`mdtensor/core/broadcast.hpp`, `tests/core/broadcast/main.cpp`) [[1]](diffhunk://#diff-d7951054ad79a887fa0aa6807e89b90e116ed53b388d52e4e2459dc826e976bdL74-R188) [[2]](diffhunk://#diff-39f7991edb781fe08db367150344847d94d7439221afe2f72cea133596e790afL7-R59)

### New public broadcasting utility

* Added a new `broadcast_to` function in `mdtensor/manipulation/broadcast_to.hpp` for broadcasting arrays to new extents, with appropriate static and runtime checks. This is now included in the manipulation module interface. (`mdtensor/manipulation/broadcast_to.hpp`, `mdtensor/manipulation/manipulation.hpp`) [[1]](diffhunk://#diff-f2d0bb4048f9050ae048520f7f9817ff6ef7347eae2118de4f9c897775076aacR1-R95) [[2]](diffhunk://#diff-59068cf6548fdbc0db49cad01c74475c3352c4c18ddb23f8f37339dc337cca26R12)

### Test updates and additions

* Updated existing tests to use the new function names (`broadcast_extents`, `broadcast_axes_to`) and added new tests for the new `broadcast_to` utility. (`tests/core/broadcast/main.cpp`, `tests/manipulation/broadcast_to/main.cpp`, `tests/manipulation/broadcast_to/BUILD.bazel`) [[1]](diffhunk://#diff-39f7991edb781fe08db367150344847d94d7439221afe2f72cea133596e790afL7-R59) [[2]](diffhunk://#diff-3f907dc51c1c60f72c5a5ea92ce4cd6e37149635923e92ba8d9ca02d04858bfbR1-R17) [[3]](diffhunk://#diff-dc43a3207aec23866e12476116baa0ad949aed4725bd0e647dd8a727b3bba1fdR1-R17)

### Minor improvements

* Improved the `common_index_type_impl` template to handle triple and variadic type deduction, and added corresponding tests. (`mdtensor/core/type.hpp`, `tests/core/common_type/data/main.cpp`, `tests/core/common_type/index/main.cpp`) [[1]](diffhunk://#diff-b23b15b9c21b2c43d470d871a1d5f424aaf1a5cc3b8108fd2f8dadf6c33df2b2L324-R325) [[2]](diffhunk://#diff-646a34c984fff2c248ff0c76b8364a86b2dfbffe3fdb48fc7cb9804cbbf1dd55R154-R157) [[3]](diffhunk://#diff-0520a59e7164513e4b24687fac51144a79bdcea6d87ed79d2eba007fc1ad6557R100-R103)
* Updated usage of the new `concatenate_extents` function in `linspace` creation utility. (`mdtensor/creation/linspace.hpp`)